### PR TITLE
Potential fix for code scanning alert no. 4: Log entries created from user input

### DIFF
--- a/Connectors/Services/DataverseService.cs
+++ b/Connectors/Services/DataverseService.cs
@@ -64,7 +64,8 @@ namespace PowerPlatformConnector.Services
         {
             try
             {
-                _logger.LogInformation("Retrieving columns for table: {TableName}", tableName);
+                var sanitizedTableName = tableName?.Replace("\r", "").Replace("\n", "");
+                _logger.LogInformation("Retrieving columns for table: {TableName}", sanitizedTableName);
                 var token = await _authService.GetAccessTokenAsync(cancellationToken);
                 var apiUrl = $"{_config.EnvironmentUrl}/api/data/v9.2/EntityDefinitions(LogicalName='{tableName}')/Attributes";
 
@@ -86,7 +87,8 @@ namespace PowerPlatformConnector.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving columns for table {TableName}", tableName);
+                var sanitizedTableName = tableName?.Replace("\r", "").Replace("\n", "");
+                _logger.LogError(ex, "Error retrieving columns for table {TableName}", sanitizedTableName);
                 throw;
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Electric-G-Ltd/P100-PowerPlatform-ALM/security/code-scanning/4](https://github.com/Electric-G-Ltd/P100-PowerPlatform-ALM/security/code-scanning/4)

To fix the log-forging vulnerability, sanitize the user input before writing it to the log. For logs that will be stored or viewed as plain text, escape or remove any newline (`\n`, `\r`) characters, and possibly other control characters, from the user-provided values before logging them. The simplest robust fix is to replace newline characters in `tableName` with empty strings or a visible character (e.g., `"_"`) right before they are logged. This change should be made in the logging calls at line 67 (and for completeness, also line 89) in `Connectors/Services/DataverseService.cs`. No new dependencies are required, as string replacement is built-in.   

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
